### PR TITLE
CI: add 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: false
 language: ruby
 rvm:
   - 2.5
-before_install: gem install bundler
+  - 2.6


### PR DESCRIPTION
  - Drop unused sudo: false Travis directive

This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

--

also: adds Ruby 2.6 to the matrix.