### PR TITLE
Change active storage dependency.

### DIFF
--- a/activestorage_webdav.gemspec
+++ b/activestorage_webdav.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 2.1'
   spec.add_development_dependency 'rack_dav'
 
-  spec.add_runtime_dependency 'activestorage', '~> 5.2'
+  spec.add_runtime_dependency 'activestorage', '>= 5.2'
   spec.add_runtime_dependency 'net_dav', '~> 0.5.1'
 end

--- a/lib/activestorage_webdav/version.rb
+++ b/lib/activestorage_webdav/version.rb
@@ -1,3 +1,3 @@
 module ActivestorageWebdav
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end


### PR DESCRIPTION
Actual runtime dependency of active storage blocks rails from being updated.